### PR TITLE
Return status code 1 if errors are found

### DIFF
--- a/Main.d
+++ b/Main.d
@@ -94,7 +94,7 @@ checks = mixin(
    errors += checkEntry(arg);
  }
 
-  return 0;
+  return errors == 0 ? 0 : 1;
 }
 
 auto makeHashtable(T...)() {


### PR DESCRIPTION
The original Main.d returned always 0, and there was no method to programatically detect errors.
Descriptive status code makes it easy to integrate flint into build processes, such as CI.