### PR TITLE
Added Dockerfile to make it easier for people to try out flint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+FROM ubuntu:trusty
+MAINTAINER Lukas Martinelli <me@lukasmartinelli.ch>
+
+# install dependencies for building facebook libraries
+RUN apt-get update && apt-get install -y \
+    g++ \
+    gdc \
+    automake \
+    autoconf \
+    autoconf-archive \
+    libtool \
+    libboost-all-dev \
+    libevent-dev \
+    libdouble-conversion-dev \
+    libgoogle-glog-dev \
+    libgflags-dev \
+    liblz4-dev \
+    liblzma-dev \
+    libsnappy-dev \
+    make \
+    zlib1g-dev \
+    binutils-dev \
+    libjemalloc-dev \
+    libssl-dev \
+    libiberty-dev \
+    scons \
+    git \
+    wget \
+    unzip
+
+# build and install folly
+WORKDIR /tmp/build
+RUN git clone https://github.com/facebook/folly
+WORKDIR folly/folly
+RUN wget https://googletest.googlecode.com/files/gtest-1.6.0.zip && \
+    unzip gtest-1.6.0.zip -d test
+RUN autoreconf -ivf && \
+    ./configure && \
+    make check && \
+    make install
+
+# build and install double-conversion
+WORKDIR /tmp/build
+RUN git clone https://github.com/floitsch/double-conversion.git
+WORKDIR double-conversion
+RUN scons install
+
+# build and install flint
+WORKDIR /tmp/build
+RUN git clone https://github.com/facebook/flint
+WORKDIR flint
+RUN wget https://googletest.googlecode.com/files/gtest-1.6.0.zip && \
+    unzip gtest-1.6.0.zip -d cxx
+ENV LDFLAGS -L/root/double-conversion
+ENV CPPFLAGS -I/root/double-conversion/src
+RUN autoreconf --install && \
+    ./configure --with-boost-libdir=/usr/lib/x86_64-linux-gnu && \
+    make && \
+#   make check && \
+    make install
+
+# cleanup build
+WORKDIR /root
+RUN rm -r /tmp/build
+
+ENV LD_LIBRARY_PATH /usr/local/lib
+ENTRYPOINT ["/usr/local/bin/flint"]

--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ To Build
     autoreconf --install
     LDFLAGS=-L<double-conversion> CPPFLAGS=-I<double-conversion>/src configure ...
     make
+
+Build and run with Docker
+-------------------------
+
+Run flint on a repository of yours by mounting it into the `/root` folder of the docker container.
+
+```
+sudo docker build -t facebook/flint .
+docker run -v /path/to/your/project/src:/root facebook/flint /root
+```


### PR DESCRIPTION
Hi guys, I really like what you did with flint! :+1: 
I think it is a great tool anyone should incorporate into their build chain.

However when I wanted to try flint for the first time I found it quite a hassle to build it - which makes it hard for people to simply run the flynn checker on their code and get a first overview what flint can do.

I already created [a docker image](https://github.com/lukasmartinelli/docker-flint) but I think it would be best if there would be an official flint docker image and a note in README so that people who have Docker installed can try out flint with one command.

What do you think?