### PR TITLE
Added more c functions to the list of blacklisted identifiers.

### DIFF
--- a/Checks.d
+++ b/Checks.d
@@ -542,11 +542,38 @@ uint checkBlacklistedIdentifiers(string fpath, CppLexer.Token[] v) {
 
   string[string] banned = [
     "strtok" :
-      "strtok() is not thread safe, and has safer alternatives.  Consider "
+      "strtok is not thread safe, and has safer alternatives.  Consider "
       "folly::split or strtok_r as appropriate.\n",
     "strncpy" :
       "strncpy is very often used in error; see "
-      "http://meyering.net/crusade-to-eliminate-strncpy/\n"
+      "http://meyering.net/crusade-to-eliminate-strncpy/\n",
+    "strcpy" :
+      "strcpy is not buffer overflow safe; see "
+      "http://meyering.net/crusade-to-eliminate-strncpy/\n",
+    "strcat":
+      "strcat is not buffer overflow safe. Consider using strncat. See"
+      "http://linux.die.net/man/3/strcat",
+    "sprintf":
+      "sprintf is not buffer overflow safe. Consider using snprintf. See"
+      "http://linux.die.net/man/3/printf",
+    "vsprintf":
+      "vsprintf is not buffer overflow safe. Consider using vsnprintf. See"
+      "http://linux.die.net/man/3/printf",
+    "gets":
+      "Never use gets as is not buffer overflow safe, use fgets instead. See"
+      "http://linux.die.net/man/3/fgetc",
+    "asctime":
+      "asctime is not thread safe. Consider using asctime_r instead. See"
+      "http://linux.die.net/man/3/asctime",
+    "ctime":
+      "ctime is not thread safe. Consider using ctime_r instead. See"
+      "http://linux.die.net/man/3/asctime",
+    "gmtime":
+      "gmtime is not thread safe. Consider using gmtime_r instead. See"
+      "http://linux.die.net/man/3/asctime",
+    "localtime":
+      "localtime is not thread safe. Consider using localtime_r instead. See"
+      "http://linux.die.net/man/3/asctime"
   ];
 
   foreach (ref t; v) {

--- a/Test.d
+++ b/Test.d
@@ -34,23 +34,6 @@ int main()
 
 unittest {
   string s = "
-#include <string>
-// Some code does this, (good!), and someday we may want to exempt
-// such usage from this lint rule.
-#define strncpy(d,s,n) do_not_use_this_function
-int main() {
-  // Using strncpy(a,b,c) in a comment does not provoke a warning.
-  char buf[10];
-  strncpy(buf, \"foo\", 3);
-  return 0;
-}
-";
-  auto tokens = tokenize(s, "nofile.cpp");
-  EXPECT_EQ(checkBlacklistedIdentifiers("nofile.cpp", tokens), 2);
-}
-
-unittest {
-  string s = "
 #include <vector>
 #include <list1>
 #include <algorith>
@@ -304,6 +287,44 @@ volatile int foo;
 unittest {
   string filename = "nofile.cpp";
 
+  string s = "
+#include <string>
+// Some code does this, (good!), and someday we may want to exempt
+// such usage from this lint rule.
+#define strncpy(d,s,n) do_not_use_this_function
+int main() {
+  // Using strncpy(a,b,c) in a comment does not provoke a warning.
+  char buf[10];
+  strncpy(buf, \"foo\", 3);
+  return 0;
+}
+";
+  auto tokens = tokenize(s, filename);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 2);
+}
+
+unittest {
+  string filename = "nofile.cpp";
+
+  string s = "
+#include <string>
+// Some code does this, (good!), and someday we may want to exempt
+// such usage from this lint rule.
+#define strcpy(d,s) do_not_use_this_function
+int main() {
+  // Using strcpy(a,b) in a comment does not provoke a warning.
+  char buf[10];
+  strcpy(buf, \"foo\", 3);
+  return 0;
+}
+";
+  auto tokens = tokenize(s, filename);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 2);
+}
+
+unittest {
+  string filename = "nofile.cpp";
+
   string s = "(
 int main(int argc, char** argv) {
   auto p = strtok(argv[0], ',');
@@ -313,7 +334,7 @@ int main(int argc, char** argv) {
 }
 )";
   Token[] tokens = tokenize(s, filename);
-  assert(checkBlacklistedIdentifiers(filename, tokens) == 2);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 2);
 
   string s1 = "(
 int main(int argc, char** argv) {
@@ -325,7 +346,111 @@ int main(int argc, char** argv) {
 }
 )";
   tokens = tokenize(s1, filename);
-  assert(checkBlacklistedIdentifiers(filename, tokens) == 0);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 0);
+}
+
+unittest {
+  string filename = "nofile.cpp";
+
+  string s = "(
+int main(int argc, char** argv) {
+  strcat(dest, src);
+  strncat(dest, src, size);
+}
+)";
+  Token[] tokens = tokenize(s, filename);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 1);
+}
+
+unittest {
+  string filename = "nofile.cpp";
+
+  string s = "(
+int main(int argc, char** argv) {
+  sprintf(dest, format);
+  snprintf(dest, size, format);
+}
+)";
+  Token[] tokens = tokenize(s, filename);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 1);
+}
+
+unittest {
+  string filename = "nofile.cpp";
+
+  string s = "(
+int main(int argc, char** argv) {
+  vsprintf(dest, format);
+  vsnprintf(dest, size, format);
+}
+)";
+  Token[] tokens = tokenize(s, filename);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 1);
+}
+
+unittest {
+  string filename = "nofile.cpp";
+
+  string s = "(
+int main(int argc, char** argv) {
+  gets(s);
+  fgets(s, size, stream);
+}
+)";
+  Token[] tokens = tokenize(s, filename);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 1);
+}
+
+unittest {
+  string filename = "nofile.cpp";
+
+  string s = "(
+int main(int argc, char** argv) {
+  asctime(tm);
+  asctime_r(tm, buf);
+}
+)";
+  Token[] tokens = tokenize(s, filename);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 1);
+}
+
+unittest {
+  string filename = "nofile.cpp";
+
+  string s = "(
+int main(int argc, char** argv) {
+  ctime(timep);
+  ctime_r(timep, buf);
+}
+)";
+  Token[] tokens = tokenize(s, filename);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 1);
+}
+
+unittest {
+  string filename = "nofile.cpp";
+
+  string s = "(
+int main(int argc, char** argv) {
+  gmtime(timep);
+  gmtime_r(timep, result);
+}
+)";
+  Token[] tokens = tokenize(s, filename);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 1);
+}
+
+unittest {
+  string filename = "nofile.cpp";
+
+  string s = "(
+int main(int argc, char** argv) {
+  localtime(timep);
+  localtime_r(timep, result);
+}
+)";
+  Token[] tokens = tokenize(s, filename);
+  EXPECT_EQ(checkBlacklistedIdentifiers(filename, tokens), 1);
 }
 
 // Test catch clauses in exceptions


### PR DESCRIPTION
The identifiers added are:
- strcpy
- strcat
- gets
- sprintf
- vsprintf
- asctime
- ctime
- gmtime
- localtime

The existing tests for blacklisted identifiers were normalized as well.
